### PR TITLE
Allow user to specify list seperator

### DIFF
--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -200,17 +200,19 @@ class Photo(VCardTextBehavior):
 
 registerBehavior(Photo)
 
-def toListOrString(string):
-    stringList = stringToTextValues(string)
+def toListOrString(string, listSeparator=","):
+    stringList = stringToTextValues(string, listSeparator=listSeparator)
     if len(stringList) == 1:
         return stringList[0]
     else:
         return stringList
 
-def splitFields(string):
+def splitFields(string, toListOrStringListSeperator=","):
     """Return a list of strings or lists from a Name or Address."""
-    return [toListOrString(i) for i in
-            stringToTextValues(string, listSeparator=';', charList=';')]
+    return [
+        toListOrString(i, listSeparator=toListOrStringListSeperator) for i in
+            stringToTextValues(string, listSeparator=';', charList=';')
+        ]
 
 def toList(stringOrList):
     if isinstance(stringOrList, basestring):
@@ -240,11 +242,13 @@ class NameBehavior(VCardBehavior):
     hasNative = True
 
     @staticmethod
-    def transformToNative(obj):
+    def transformToNative(obj, toListOrStringListSeperator=","):
         """Turn obj.value into a Name."""
         if obj.isNative: return obj
         obj.isNative = True
-        obj.value = Name(**dict(zip(NAME_ORDER, splitFields(obj.value))))
+        obj.value = Name(**dict(zip(NAME_ORDER, splitFields(
+            obj.value, toListOrStringListSeperator=toListOrStringListSeperator
+        ))))
         return obj
 
     @staticmethod
@@ -263,11 +267,14 @@ class AddressBehavior(VCardBehavior):
     hasNative = True
 
     @staticmethod
-    def transformToNative(obj):
+    def transformToNative(obj, toListOrStringListSeperator=","):
         """Turn obj.value into an Address."""
         if obj.isNative: return obj
         obj.isNative = True
-        obj.value = Address(**dict(zip(ADDRESS_ORDER, splitFields(obj.value))))
+        obj.value = Address(**dict(zip(ADDRESS_ORDER, splitFields(
+            obj.value,
+            toListOrStringListSeperator=toListOrStringListSeperator
+        ))))
         return obj
 
     @staticmethod
@@ -283,11 +290,13 @@ class OrgBehavior(VCardBehavior):
     hasNative = True
 
     @staticmethod
-    def transformToNative(obj):
+    def transformToNative(obj, toListOrStringListSeperator=","):
         """Turn obj.value into a list."""
         if obj.isNative: return obj
         obj.isNative = True
-        obj.value = splitFields(obj.value)
+        obj.value = splitFields(
+            obj.value, toListOrStringListSeperator=toListOrStringListSeperator
+        )
         return obj
 
     @staticmethod


### PR DESCRIPTION
There was an issue with certain vcard fields containing commas. The method toListOrString was automatically splitting strings like `"My Company, LLC"` into a list of two strings: `["My Company", "LLC"]`, which was causing issues for the parser downstream.

I've added an optional argument to the method, which defaults to `","`, but allows the user to specify what separator to use. This will allow us to use `None` for our purposes, but shouldn't change the behavior in any other context.